### PR TITLE
Add pglite option for schema generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ npm install pgstrap --save-dev
 
 - `npm run db:migrate` - Run pending migrations
 - `npm run db:reset` - Drop and recreate the database, then run all migrations
-- `npm run db:generate` - Generate types and structure dumps
+- `npm run db:generate` - Generate types and structure dumps. Use `pgstrap generate --pglite` to run migrations against an in-memory PGlite instance.
 - `npm run db:create-migration` - Create a new migration file
 
 ### Configuration

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
       "name": "pgstrap",
       "dependencies": {
         "@electric-sql/pglite": "^0.3.3",
+        "pg-gateway": "^0.3.0-beta.4",
         "pg-schema-dump": "^2.0.2",
         "yargs": "^17.7.2",
       },
@@ -298,6 +299,8 @@
     "pg-connection-from-env": ["pg-connection-from-env@1.1.0", "", { "dependencies": { "pg-connection-string": "^2.5.0" } }, "sha512-Bwjd2GU9TXQhNf3ah4j9Q/0ttOi5z0537Us9hS7C7QjBuNLJnkZ6PboGY2uTrhZ+uEriKNYqjXNFB1LPpKg88w=="],
 
     "pg-connection-string": ["pg-connection-string@2.6.2", "", {}, "sha512-ch6OwaeaPYcova4kKZ15sbJ2hKb/VP48ZD2gE7i1J+L4MspCtBMAx8nMgz7bksc7IojCIIWuEhHibSMFH8m8oA=="],
+
+    "pg-gateway": ["pg-gateway@0.3.0-beta.4", "", {}, "sha512-CTjsM7Z+0Nx2/dyZ6r8zRsc3f9FScoD5UAOlfUx1Fdv/JOIWvRbF7gou6l6vP+uypXQVoYPgw8xZDXgMGvBa4Q=="],
 
     "pg-int8": ["pg-int8@1.0.1", "", {}, "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="],
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "license": "MIT",
   "dependencies": {
     "@electric-sql/pglite": "^0.3.3",
+    "pg-gateway": "^0.3.0-beta.4",
     "pg-schema-dump": "^2.0.2",
     "yargs": "^17.7.2"
   },

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -34,9 +34,11 @@ import { getProjectContext } from "./get-project-context"
   .command(
     "generate",
     "generate types and sql documentation from database",
-    {},
-    async () => {
-      generate(await getProjectContext())
+    (yargs) => {
+      yargs.option("pglite", { type: "boolean", default: false })
+    },
+    async (argv) => {
+      generate({ ...(await getProjectContext()), pglite: !!argv.pglite })
     },
   )
   .parse()

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -6,13 +6,91 @@ import {
 import { Context } from "./get-project-context"
 import { dumpTree } from "pg-schema-dump"
 import path from "path"
+import { migrate } from "./migrate"
 
 export const generate = async ({
   schemas,
   defaultDatabase,
   dbDir,
-}: Pick<Context, "schemas" | "defaultDatabase" | "dbDir">) => {
+  pglite = false,
+  migrationsDir,
+}: Pick<Context, "schemas" | "defaultDatabase" | "dbDir"> & {
+  pglite?: boolean
+  migrationsDir?: string
+}) => {
   dbDir = dbDir ?? "./src/db"
+  migrationsDir = migrationsDir ?? path.join(dbDir, "migrations")
+
+  if (pglite) {
+    const { PGlite } = await import("@electric-sql/pglite")
+    const { fromNodeSocket, closeSignal } = await import("pg-gateway/node")
+    const net = await import("node:net")
+
+    const db = new PGlite()
+
+    await migrate({
+      client: db as any,
+      migrationsDir,
+      defaultDatabase,
+      cwd: process.cwd(),
+      schemas,
+    })
+
+    const server = net.createServer(async (socket) => {
+      const connection = await fromNodeSocket(socket, {
+        serverVersion: "16.3 (PGlite)",
+        auth: {
+          method: "password",
+          validateCredentials: ({ username, password }: any) =>
+            username === "postgres" && password === "postgres",
+          getClearTextPassword: () => "postgres",
+        },
+        async onStartup() {
+          await (db as any).waitReady
+          return false
+        },
+        async onMessage(data: Uint8Array, { isAuthenticated }: any) {
+          if (!isAuthenticated) return false
+          try {
+            const [[, responseData]] = await (db as any).execProtocol(data)
+            connection.sendData(responseData)
+          } catch (err) {
+            connection.sendError(err as any)
+            connection.sendReadyForQuery()
+          }
+          return true
+        },
+      })
+    })
+
+    await new Promise((res) => server.listen(0, res))
+    const port = (server.address() as any).port
+    const connectionString = `postgres://postgres:postgres@127.0.0.1:${port}/postgres`
+
+    const prevDbUrl = process.env.DATABASE_URL
+    process.env.DATABASE_URL = connectionString
+
+    await zg.generate({
+      db: {
+        connectionString,
+      },
+      schemas: Object.fromEntries(
+        schemas.map((s) => [s, { include: "*", exclude: [] }]),
+      ),
+      outDir: dbDir,
+    })
+
+    await dumpTree({
+      targetDir: path.join(dbDir, "structure"),
+      defaultDatabase: "postgres",
+      schemas,
+    })
+
+    server.close()
+    if (prevDbUrl === undefined) delete process.env.DATABASE_URL
+    else process.env.DATABASE_URL = prevDbUrl
+    return
+  }
 
   await zg.generate({
     db: {

--- a/tests/generate.pglite.test.ts
+++ b/tests/generate.pglite.test.ts
@@ -1,0 +1,47 @@
+import { test, expect } from "bun:test"
+import fs from "fs"
+import os from "os"
+import path from "path"
+import { generate } from "../src/generate"
+
+const migrationFile = `
+exports.up = async (pgm) => {
+  pgm.createTable('foo', { id: 'id' })
+}
+exports.down = async (pgm) => {
+  pgm.dropTable('foo')
+}
+`
+
+test("generate with pglite runs migrations and dumps structure", async () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "pgstrap-generate-"))
+  const migrationsDir = path.join(tmp, "migrations")
+  fs.mkdirSync(migrationsDir, { recursive: true })
+  fs.writeFileSync(
+    path.join(migrationsDir, "001_create_table.js"),
+    migrationFile,
+  )
+
+  await generate({
+    schemas: ["public"],
+    defaultDatabase: "postgres",
+    dbDir: path.join(tmp, "db"),
+    migrationsDir,
+    pglite: true,
+  })
+
+  const zapatosFile = path.join(tmp, "db", "zapatos", "schema.d.ts")
+  const structureDir = path.join(
+    tmp,
+    "db",
+    "structure",
+    "public",
+    "tables",
+    "foo",
+  )
+
+  expect(fs.existsSync(zapatosFile)).toBe(true)
+  expect(fs.existsSync(path.join(structureDir, "table.sql"))).toBe(true)
+
+  fs.rmSync(tmp, { recursive: true, force: true })
+})


### PR DESCRIPTION
## Summary
- support `pgstrap generate --pglite` to run migrations using an in-memory PGlite database
- expose `--pglite` option in CLI
- document how to use the new flag
- update dependencies and lockfile

## Testing
- `bun test tests`

------
https://chatgpt.com/codex/tasks/task_b_684eebd07aac832e81f2e1875d77643b