### PR TITLE
Default pgstrap generate to PGlite

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ npm install pgstrap --save-dev
    ```bash
    npm run db:generate
    ```
+   This runs against an in-memory PGlite database by default, so no local Postgres server is required.
 
 ## Usage
 
@@ -55,7 +56,7 @@ npm install pgstrap --save-dev
 
 - `npm run db:migrate` - Run pending migrations
 - `npm run db:reset` - Drop and recreate the database, then run all migrations
-- `npm run db:generate` - Generate types and structure dumps. Use `pgstrap generate --pglite` to run migrations against an in-memory PGlite instance.
+- `npm run db:generate` - Generate types and structure dumps using an in-memory PGlite instance. Use `pgstrap generate --no-pglite` to connect to a running Postgres database instead.
 - `npm run db:create-migration` - Create a new migration file
 
 ### Configuration

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "test": "bun test",
     "build": "tsup ./src/index.ts ./src/cli.ts --outDir ./dist --dts --sourcemap inline",
+    "db:generate": "bun run ./src/generate.ts",
     "format": "biome format . --write",
     "format:check": "biome format ."
   },

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -35,10 +35,18 @@ import { getProjectContext } from "./get-project-context"
     "generate",
     "generate types and sql documentation from database",
     (yargs) => {
-      yargs.option("pglite", { type: "boolean", default: false })
+      yargs.option("pglite", {
+        type: "boolean",
+        default: true,
+        describe:
+          "Use an in-memory PGlite instance. Pass --no-pglite to connect to a running Postgres database.",
+      })
     },
     async (argv) => {
-      generate({ ...(await getProjectContext()), pglite: !!argv.pglite })
+      await generate({
+        ...(await getProjectContext()),
+        pglite: argv.pglite !== false,
+      })
     },
   )
   .parse()

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -12,7 +12,7 @@ export const generate = async ({
   schemas,
   defaultDatabase,
   dbDir,
-  pglite = false,
+  pglite = true,
   migrationsDir,
 }: Pick<Context, "schemas" | "defaultDatabase" | "dbDir"> & {
   pglite?: boolean
@@ -60,7 +60,9 @@ export const generate = async ({
       })
     })
 
-    await new Promise<void>((resolve) => server.listen(0, resolve))
+    await new Promise<void>((resolve) =>
+      server.listen(0, "127.0.0.1", resolve),
+    )
     const port = (server.address() as any).port
     const connectionString = `postgres://postgres:postgres@127.0.0.1:${port}/postgres`
 

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -60,9 +60,7 @@ export const generate = async ({
       })
     })
 
-    await new Promise<void>((resolve) =>
-      server.listen(0, "127.0.0.1", resolve),
-    )
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve))
     const port = (server.address() as any).port
     const connectionString = `postgres://postgres:postgres@127.0.0.1:${port}/postgres`
 

--- a/tests/generate.pglite.test.ts
+++ b/tests/generate.pglite.test.ts
@@ -13,7 +13,7 @@ exports.down = async (pgm) => {
 }
 `
 
-test("generate with pglite runs migrations and dumps structure", async () => {
+test("generate defaults to pglite and dumps structure", async () => {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "pgstrap-generate-"))
   const migrationsDir = path.join(tmp, "migrations")
   fs.mkdirSync(migrationsDir, { recursive: true })
@@ -27,7 +27,6 @@ test("generate with pglite runs migrations and dumps structure", async () => {
     defaultDatabase: "postgres",
     dbDir: path.join(tmp, "db"),
     migrationsDir,
-    pglite: true,
   })
 
   const zapatosFile = path.join(tmp, "db", "zapatos", "schema.d.ts")


### PR DESCRIPTION
## Summary

- Make pgstrap generate default to an in-memory PGlite instance so Postgres isn’t required.
- Update CLI flag handling, docs, and tests.
- Add a Bun helper script to run generator directly.

/claim #2 
ref: #2 