### PR TITLE
Use PGlite by default for CLI generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,18 @@ npm install pgstrap --save-dev
 
 - `npm run db:migrate` - Run pending migrations
 - `npm run db:reset` - Drop and recreate the database, then run all migrations
-- `npm run db:generate` - Generate types and structure dumps. Use `pgstrap generate --pglite` to run migrations against an in-memory PGlite instance.
+- `npm run db:generate` - Run migrations in an in-memory PGlite database and generate types and structure dumps. No running PostgreSQL server is needed.
 - `npm run db:create-migration` - Create a new migration file
+
+`pgstrap generate` uses PGlite by default, including through an existing
+`db:generate` script. It rebuilds the schema from the project's migration files
+and does not read a live database. The temporary database and its localhost-only
+gateway are closed after generation, including when generation fails.
+
+To inspect an existing PostgreSQL database, or use migrations requiring
+extensions that PGlite does not support, run `pgstrap generate --no-pglite`
+with your normal connection environment. Programmatic callers can select the
+in-memory path with `generate({ ...context, pglite: true })`.
 
 ### Configuration
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -35,10 +35,15 @@ import { getProjectContext } from "./get-project-context"
     "generate",
     "generate types and sql documentation from database",
     (yargs) => {
-      yargs.option("pglite", { type: "boolean", default: false })
+      yargs.option("pglite", {
+        type: "boolean",
+        default: true,
+        describe:
+          "Generate from in-memory migrations; use --no-pglite for PostgreSQL",
+      })
     },
     async (argv) => {
-      generate({ ...(await getProjectContext()), pglite: !!argv.pglite })
+      await generate({ ...(await getProjectContext()), pglite: !!argv.pglite })
     },
   )
   .parse()

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -28,16 +28,11 @@ export const generate = async ({
 
     const db = new PGlite()
 
-    await migrate({
-      client: db as any,
-      migrationsDir,
-      defaultDatabase,
-      cwd: process.cwd(),
-      schemas,
-    })
-
-    const server = net.createServer(async (socket) => {
-      const connection = await fromNodeSocket(socket, {
+    const sockets = new Set<import("node:net").Socket>()
+    const server = net.createServer((socket) => {
+      sockets.add(socket)
+      socket.once("close", () => sockets.delete(socket))
+      void fromNodeSocket(socket, {
         serverVersion: "16.3 (PGlite)",
         auth: {
           method: "password",
@@ -46,46 +41,73 @@ export const generate = async ({
           getClearTextPassword: () => "postgres",
         },
         async onStartup() {
-          await (db as any).waitReady
+          await db.waitReady
         },
         async onMessage(data: Uint8Array, { isAuthenticated }: any) {
           if (!isAuthenticated) return
-          try {
-            const { data: responseData } = await (db as any).execProtocol(data)
-            return responseData
-          } catch {
-            return undefined
-          }
+          const { data: responseData } = await db.execProtocol(data, {
+            throwOnError: false,
+          })
+          return responseData
         },
+      }).catch(() => socket.destroy())
+    })
+
+    const previousPostgresUri = process.env.POSTGRES_URI
+    let connectionOverrideActive = false
+    try {
+      await migrate({
+        client: db as any,
+        migrationsDir,
+        defaultDatabase,
+        cwd: process.cwd(),
+        schemas,
       })
-    })
 
-    await new Promise<void>((resolve) => server.listen(0, resolve))
-    const port = (server.address() as any).port
-    const connectionString = `postgres://postgres:postgres@127.0.0.1:${port}/postgres`
+      await new Promise<void>((resolve, reject) => {
+        server.once("error", reject)
+        server.listen(0, "127.0.0.1", () => {
+          server.off("error", reject)
+          resolve()
+        })
+      })
+      const port = (server.address() as import("node:net").AddressInfo).port
+      const connectionString = `postgres://postgres:postgres@127.0.0.1:${port}/postgres`
 
-    const prevDbUrl = process.env.DATABASE_URL
-    process.env.DATABASE_URL = connectionString
+      // pg-schema-dump resolves this before PG_URI and DATABASE_URL.
+      // Its temporary connection must not fall back to a configured server.
+      process.env.POSTGRES_URI = connectionString
+      connectionOverrideActive = true
 
-    await zg.generate({
-      db: {
-        connectionString,
-      },
-      schemas: Object.fromEntries(
-        schemas.map((s) => [s, { include: "*", exclude: [] }]),
-      ),
-      outDir: dbDir,
-    })
+      await zg.generate({
+        db: { connectionString },
+        schemas: Object.fromEntries(
+          schemas.map((s) => [s, { include: "*", exclude: [] }]),
+        ),
+        outDir: dbDir,
+      })
 
-    await dumpTree({
-      targetDir: path.join(dbDir, "structure"),
-      defaultDatabase: "postgres",
-      schemas,
-    })
-
-    server.close()
-    if (prevDbUrl === undefined) delete process.env.DATABASE_URL
-    else process.env.DATABASE_URL = prevDbUrl
+      await dumpTree({
+        targetDir: path.join(dbDir, "structure"),
+        defaultDatabase: "postgres",
+        schemas,
+      })
+    } finally {
+      if (connectionOverrideActive) {
+        if (previousPostgresUri === undefined) delete process.env.POSTGRES_URI
+        else process.env.POSTGRES_URI = previousPostgresUri
+      }
+      for (const socket of sockets) socket.destroy()
+      try {
+        if (server.listening) {
+          await new Promise<void>((resolve, reject) => {
+            server.close((error) => (error ? reject(error) : resolve()))
+          })
+        }
+      } finally {
+        await db.close()
+      }
+    }
     return
   }
 

--- a/tests/generate.cli.test.ts
+++ b/tests/generate.cli.test.ts
@@ -1,0 +1,138 @@
+import { beforeAll, expect, test } from "bun:test"
+import fs from "fs"
+import os from "os"
+import path from "path"
+import { initPgstrap } from "../src/init"
+
+const root = path.resolve(import.meta.dir, "..")
+const unavailableDatabase = "postgres://test:test@127.0.0.1:1/unavailable"
+
+beforeAll(async () => {
+  const build = Bun.spawn([process.execPath, "run", "build"], {
+    cwd: root,
+    stdout: "pipe",
+    stderr: "pipe",
+  })
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(build.stdout).text(),
+    new Response(build.stderr).text(),
+    build.exited,
+  ])
+  if (exitCode !== 0) throw new Error(`${stdout}\n${stderr}`)
+}, 20000)
+
+async function runGeneratedScript(options: {
+  args?: string[]
+  brokenMigration?: boolean
+  blockedOutput?: boolean
+}) {
+  const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "pgstrap-cli-"))
+  try {
+    fs.writeFileSync(
+      path.join(cwd, "package.json"),
+      JSON.stringify({ name: "fixture" }),
+    )
+    await initPgstrap({ cwd })
+    if (options.blockedOutput) {
+      fs.writeFileSync(path.join(cwd, "src/db/zapatos"), "occupied")
+    }
+    const migrationsDir = path.join(cwd, "src/db/migrations")
+    fs.mkdirSync(migrationsDir, { recursive: true })
+    fs.writeFileSync(
+      path.join(migrationsDir, "1700000000000_create_receipt_rows.js"),
+      options.brokenMigration
+        ? "exports.up = () => { throw new Error('intentional migration failure') }"
+        : "exports.up = (pgm) => pgm.createTable('receipt_rows', { id: 'id', display_name: { type: 'text', notNull: true } })",
+    )
+    const binDir = path.join(cwd, "node_modules/.bin")
+    fs.mkdirSync(binDir, { recursive: true })
+    const cli = path.join(root, "dist/cli.cjs")
+    fs.chmodSync(cli, 0o755)
+    fs.symlinkSync(cli, path.join(binDir, "pgstrap"))
+
+    const child = Bun.spawn(
+      [process.execPath, "run", "db:generate", ...(options.args ?? [])],
+      {
+        cwd,
+        env: {
+          ...process.env,
+          PATH: `${binDir}${path.delimiter}${process.env.PATH}`,
+          DATABASE_URL: unavailableDatabase,
+          POSTGRES_URI: unavailableDatabase,
+          PG_URI: unavailableDatabase,
+          DATABASE_URI: unavailableDatabase,
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      },
+    )
+    let timedOut = false
+    const timer = setTimeout(() => {
+      timedOut = true
+      child.kill()
+    }, 10000)
+    let stdout: string
+    let stderr: string
+    let exitCode: number
+    try {
+      ;[stdout, stderr, exitCode] = await Promise.all([
+        new Response(child.stdout).text(),
+        new Response(child.stderr).text(),
+        child.exited,
+      ])
+    } finally {
+      clearTimeout(timer)
+    }
+    const schemaPath = path.join(cwd, "src/db/zapatos/schema.d.ts")
+    const tablePath = path.join(
+      cwd,
+      "src/db/structure/public/tables/receipt_rows/table.sql",
+    )
+    return {
+      exitCode,
+      timedOut,
+      output: `${stdout}\n${stderr}`,
+      schema: fs.existsSync(schemaPath)
+        ? fs.readFileSync(schemaPath, "utf8")
+        : "",
+      table: fs.existsSync(tablePath) ? fs.readFileSync(tablePath, "utf8") : "",
+    }
+  } finally {
+    fs.rmSync(cwd, { recursive: true, force: true })
+  }
+}
+
+test("initialized db:generate needs no external PostgreSQL server", async () => {
+  const result = await runGeneratedScript({})
+  expect(result.output).not.toContain("ECONNREFUSED")
+  expect(result.exitCode).toBe(0)
+  expect(result.timedOut).toBe(false)
+  expect(result.schema).toContain("receipt_rows")
+  expect(result.schema).toContain("display_name")
+  expect(result.table).toContain("receipt_rows")
+  expect(result.table).toContain("display_name")
+}, 15000)
+
+test("--no-pglite explicitly uses the configured PostgreSQL connection", async () => {
+  const result = await runGeneratedScript({ args: ["--no-pglite"] })
+  expect(result.exitCode).not.toBe(0)
+  expect(result.timedOut).toBe(false)
+  expect(result.output).toContain("ECONNREFUSED")
+  expect(result.schema).toBe("")
+}, 15000)
+
+test("default generation reports migration failures and exits", async () => {
+  const result = await runGeneratedScript({ brokenMigration: true })
+  expect(result.exitCode).not.toBe(0)
+  expect(result.timedOut).toBe(false)
+  expect(result.output).toContain("intentional migration failure")
+  expect(result.schema).toBe("")
+}, 15000)
+
+test("generation exits when output cannot be written after migrations", async () => {
+  const result = await runGeneratedScript({ blockedOutput: true })
+  expect(result.exitCode).not.toBe(0)
+  expect(result.timedOut).toBe(false)
+  expect(result.output).toMatch(/EEXIST|ENOTDIR/)
+  expect(result.schema).toBe("")
+}, 15000)

--- a/tests/generate.pglite.test.ts
+++ b/tests/generate.pglite.test.ts
@@ -22,13 +22,22 @@ test("generate with pglite runs migrations and dumps structure", async () => {
     migrationFile,
   )
 
-  await generate({
-    schemas: ["public"],
-    defaultDatabase: "postgres",
-    dbDir: path.join(tmp, "db"),
-    migrationsDir,
-    pglite: true,
-  })
+  const previousUri = process.env.POSTGRES_URI
+  const unavailableUri = "postgres://test:test@127.0.0.1:1/unavailable"
+  process.env.POSTGRES_URI = unavailableUri
+  try {
+    await generate({
+      schemas: ["public"],
+      defaultDatabase: "postgres",
+      dbDir: path.join(tmp, "db"),
+      migrationsDir,
+      pglite: true,
+    })
+    expect(process.env.POSTGRES_URI).toBe(unavailableUri)
+  } finally {
+    if (previousUri === undefined) delete process.env.POSTGRES_URI
+    else process.env.POSTGRES_URI = previousUri
+  }
 
   const zapatosFile = path.join(tmp, "db", "zapatos", "schema.d.ts")
   const structureDir = path.join(
@@ -44,4 +53,36 @@ test("generate with pglite runs migrations and dumps structure", async () => {
   expect(fs.existsSync(path.join(structureDir, "table.sql"))).toBe(true)
 
   fs.rmSync(tmp, { recursive: true, force: true })
+})
+
+test("pglite generation restores connection settings after output failure", async () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "pgstrap-output-failure-"))
+  const migrationsDir = path.join(tmp, "migrations")
+  fs.mkdirSync(migrationsDir)
+  fs.writeFileSync(
+    path.join(migrationsDir, "001_create_table.js"),
+    migrationFile,
+  )
+  const dbDir = path.join(tmp, "db")
+  fs.mkdirSync(dbDir)
+  fs.writeFileSync(path.join(dbDir, "zapatos"), "occupied")
+  const previousUri = process.env.POSTGRES_URI
+  const unavailableUri = "postgres://test:test@127.0.0.1:1/unchanged"
+  process.env.POSTGRES_URI = unavailableUri
+  try {
+    await expect(
+      generate({
+        schemas: ["public"],
+        defaultDatabase: "postgres",
+        dbDir,
+        migrationsDir,
+        pglite: true,
+      }),
+    ).rejects.toThrow()
+    expect(process.env.POSTGRES_URI).toBe(unavailableUri)
+  } finally {
+    if (previousUri === undefined) delete process.env.POSTGRES_URI
+    else process.env.POSTGRES_URI = previousUri
+    fs.rmSync(tmp, { recursive: true, force: true })
+  }
 })


### PR DESCRIPTION
`bun run db:generate` created by `pgstrap init` still selects the external PostgreSQL path unless `--pglite` is passed. Make CLI generation replay migrations in PGlite by default, so it creates the Zapatos declarations and SQL structure without a running PostgreSQL service. `--no-pglite` explicitly selects the existing configured-server path; programmatic callers retain their current default.

The temporary gateway binds to localhost and closes its sockets/database on success or failure. The schema dumper uses the temporary connection even when a higher-priority `POSTGRES_URI` is configured, then restores the original value. The CLI awaits generation so failures propagate through its command handler.

Closes #2.

## Validation

- `bun test --timeout 15000`: 8 passed, 30 assertions. CLI tests build the package, initialize a fresh project and run its actual `db:generate` script with all connection URI variables pointing at an unavailable database. They check generated table/column content, explicit PostgreSQL opt-out, migration errors and output-write failure exit behavior.
- The new default-command and migration-error checks failed before the feature change. Existing tests passed after restricting the test gateway to localhost.
- `bun run build`, `bun run format:check` and `git diff --check` passed. Patch application checked against the base commit.

The live PostgreSQL success path and concurrent programmatic PGlite calls were not tested. PGlite-specific extension limitations remain; `--no-pglite` supports opting back into an existing server.

Prepared with AI assistance; the listed checks were executed locally.

/claim #2